### PR TITLE
Allow to repository execute Queries

### DIFF
--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/AbstractColumnRepository.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/AbstractColumnRepository.java
@@ -25,35 +25,35 @@ import java.time.Duration;
  */
 public abstract class AbstractColumnRepository implements Repository {
 
-    protected abstract ColumnTemplate getColumnRepository();
+    protected abstract ColumnTemplate getTemplate();
 
     @Override
     public Object save(Object entity) throws NullPointerException {
-        return getColumnRepository().save(entity);
+        return getTemplate().save(entity);
     }
 
     @Override
     public Object save(Object entity, Duration ttl) {
-        return getColumnRepository().save(entity, ttl);
+        return getTemplate().save(entity, ttl);
     }
 
     @Override
     public Iterable save(Iterable entities) throws NullPointerException {
-        return getColumnRepository().save(entities);
+        return getTemplate().save(entities);
     }
 
     @Override
     public Iterable save(Iterable entities, Duration ttl) throws NullPointerException {
-        return getColumnRepository().save(entities, ttl);
+        return getTemplate().save(entities, ttl);
     }
 
     @Override
     public Object update(Object entity) {
-        return getColumnRepository().update(entity);
+        return getTemplate().update(entity);
     }
 
     @Override
     public Iterable update(Iterable entities) throws NullPointerException {
-        return getColumnRepository().update(entities);
+        return getTemplate().update(entities);
     }
 }

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/AbstractColumnRepositoryAsync.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/AbstractColumnRepositoryAsync.java
@@ -28,50 +28,50 @@ import java.util.function.Consumer;
  */
 public abstract class AbstractColumnRepositoryAsync<T> implements RepositoryAsync<T> {
 
-    protected abstract ColumnTemplateAsync getColumnRepository();
+    protected abstract ColumnTemplateAsync getTemplate();
 
     @Override
     public void save(T entity) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getColumnRepository().save(entity);
+        getTemplate().save(entity);
     }
 
     @Override
     public void save(T entity, Duration ttl) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getColumnRepository().save(entity, ttl);
+        getTemplate().save(entity, ttl);
     }
 
     @Override
     public void save(Iterable entities) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getColumnRepository().save(entities);
+        getTemplate().save(entities);
     }
 
     @Override
     public void save(Iterable entities, Duration ttl) throws NullPointerException {
-        getColumnRepository().save(entities, ttl);
+        getTemplate().save(entities, ttl);
     }
 
     @Override
     public void update(Iterable entities) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getColumnRepository().update(entities);
+        getTemplate().update(entities);
     }
 
     @Override
     public void update(Object entity) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getColumnRepository().save(entity);
+        getTemplate().save(entity);
     }
 
     @Override
     public void update(Object entity, Consumer callBack) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getColumnRepository().update(entity, callBack);
+        getTemplate().update(entity, callBack);
     }
 
     @Override
     public void save(Object entity, Duration ttl, Consumer callBack) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getColumnRepository().save(entity, ttl, callBack);
+        getTemplate().save(entity, ttl, callBack);
     }
 
     @Override
     public void save(Object entity, Consumer callBack) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getColumnRepository().save(entity, callBack);
+        getTemplate().save(entity, callBack);
     }
 }

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnQueryDeleteParser.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnQueryDeleteParser.java
@@ -25,7 +25,7 @@ import static org.jnosql.artemis.column.query.ColumnQueryParserUtil.toCondition;
 
 /**
  * Class the returns a {@link ColumnDeleteQuery}
- * on {@link ColumnCrudRepositoryProxy}
+ * on {@link ColumnRepositoryProxy}
  */
 public class ColumnQueryDeleteParser {
 

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnQueryParser.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnQueryParser.java
@@ -28,7 +28,7 @@ import static org.jnosql.artemis.column.query.ColumnQueryParserUtil.toCondition;
 
 /**
  * Class the returns a {@link ColumnQuery}
- * on {@link ColumnCrudRepositoryProxy}
+ * on {@link ColumnRepositoryProxy}
  */
 public class ColumnQueryParser {
 

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryAsyncProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryAsyncProxy.java
@@ -38,7 +38,7 @@ class ColumnRepositoryAsyncProxy<T> implements InvocationHandler {
 
     private final Class<T> typeClass;
 
-    private final ColumnTemplateAsync repository;
+    private final ColumnTemplateAsync template;
 
     private final ColumnRepositoryAsync crudRepository;
 
@@ -49,9 +49,9 @@ class ColumnRepositoryAsyncProxy<T> implements InvocationHandler {
     private final ColumnQueryDeleteParser queryDeleteParser;
 
 
-    ColumnRepositoryAsyncProxy(ColumnTemplateAsync repository, ClassRepresentations classRepresentations, Class<?> repositoryType) {
-        this.repository = repository;
-        this.crudRepository = new ColumnRepositoryAsync(repository);
+    ColumnRepositoryAsyncProxy(ColumnTemplateAsync template, ClassRepresentations classRepresentations, Class<?> repositoryType) {
+        this.template = template;
+        this.crudRepository = new ColumnRepositoryAsync(template);
         this.typeClass = Class.class.cast(ParameterizedType.class.cast(repositoryType.getGenericInterfaces()[0])
                 .getActualTypeArguments()[0]);
         this.classRepresentation = classRepresentations.get(typeClass);
@@ -88,10 +88,10 @@ class ColumnRepositoryAsyncProxy<T> implements InvocationHandler {
     private Object executeDelete(Object arg, ColumnDeleteQuery deleteQuery) {
         Object callBack = arg;
         if (Consumer.class.isInstance(callBack)) {
-            repository.delete(deleteQuery, Consumer.class.cast(callBack));
+            template.delete(deleteQuery, Consumer.class.cast(callBack));
             return Void.class;
         }
-        repository.delete(deleteQuery);
+        template.delete(deleteQuery);
         return Void.class;
     }
 
@@ -102,7 +102,7 @@ class ColumnRepositoryAsyncProxy<T> implements InvocationHandler {
     private Object executeQuery(Object arg, ColumnQuery query) {
         Object callBack = arg;
         if (Consumer.class.isInstance(callBack)) {
-            repository.find(query, Consumer.class.cast(callBack));
+            template.find(query, Consumer.class.cast(callBack));
             return null;
         }
 
@@ -113,15 +113,15 @@ class ColumnRepositoryAsyncProxy<T> implements InvocationHandler {
 
     class ColumnRepositoryAsync extends AbstractColumnRepositoryAsync implements RepositoryAsync {
 
-        private final ColumnTemplateAsync repository;
+        private final ColumnTemplateAsync template;
 
         ColumnRepositoryAsync(ColumnTemplateAsync repository) {
-            this.repository = repository;
+            this.template = repository;
         }
 
         @Override
         protected ColumnTemplateAsync getTemplate() {
-            return repository;
+            return template;
         }
     }
 }

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryAsyncProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryAsyncProxy.java
@@ -114,7 +114,7 @@ class ColumnRepositoryAsyncProxy<T> implements InvocationHandler {
         }
 
         @Override
-        protected ColumnTemplateAsync getColumnRepository() {
+        protected ColumnTemplateAsync getTemplate() {
             return repository;
         }
     }

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryAsyncProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryAsyncProxy.java
@@ -16,8 +16,8 @@
 package org.jnosql.artemis.column.query;
 
 
-import org.jnosql.artemis.RepositoryAsync;
 import org.jnosql.artemis.DynamicQueryException;
+import org.jnosql.artemis.RepositoryAsync;
 import org.jnosql.artemis.column.ColumnTemplateAsync;
 import org.jnosql.artemis.reflection.ClassRepresentation;
 import org.jnosql.artemis.reflection.ClassRepresentations;
@@ -35,11 +35,6 @@ import java.util.function.Consumer;
  * @param <T> the type
  */
 class ColumnRepositoryAsyncProxy<T> implements InvocationHandler {
-
-    private static final String SAVE = "save";
-    private static final String UPDATE = "update";
-    private static final String FIND_BY = "findBy";
-    private static final String DELETE_BY = "deleteBy";
 
     private final Class<T> typeClass;
 
@@ -69,39 +64,50 @@ class ColumnRepositoryAsyncProxy<T> implements InvocationHandler {
     public Object invoke(Object instance, Method method, Object[] args) throws Throwable {
 
         String methodName = method.getName();
-        switch (methodName) {
-            case SAVE:
-            case UPDATE:
+        ColumnRepositoryType type = ColumnRepositoryType.of(method, args);
+
+        switch (type) {
+            case DEFAULT:
                 return method.invoke(crudRepository, args);
-            default:
+            case FIND_BY:
+                ColumnQuery query = queryParser.parse(methodName, args, classRepresentation);
+                return executeQuery(getCallBack(args), query);
+            case DELETE_BY:
+                ColumnDeleteQuery deleteQuery = queryDeleteParser.parse(methodName, args, classRepresentation);
+                return executeDelete(getCallBack(args), deleteQuery);
+            case QUERY:
+                ColumnQuery columnQuery = ColumnRepositoryType.getQuery(args).get();
+                return executeQuery(getCallBack(args), columnQuery);
+            case QUERY_DELETE:
+                return executeDelete(args, ColumnRepositoryType.getDeleteQuery(args).get());
+                default:
+                    return null;
         }
+    }
 
-
-        if (methodName.startsWith(FIND_BY)) {
-            ColumnQuery query = queryParser.parse(methodName, args, classRepresentation);
-            Object callBack = args[args.length - 1];
-            if (Consumer.class.isInstance(callBack)) {
-                repository.find(query, Consumer.class.cast(callBack));
-                return null;
-            }
-
-            throw new DynamicQueryException("On find async method you must put a java.util.function.Consumer" +
-                    " as end parameter as callback");
+    private Object executeDelete(Object arg, ColumnDeleteQuery deleteQuery) {
+        Object callBack = arg;
+        if (Consumer.class.isInstance(callBack)) {
+            repository.delete(deleteQuery, Consumer.class.cast(callBack));
+            return Void.class;
         }
+        repository.delete(deleteQuery);
+        return Void.class;
+    }
 
-        if (methodName.startsWith(DELETE_BY)) {
-            Object callBack = args[args.length - 1];
-            ColumnDeleteQuery query = queryDeleteParser.parse(methodName, args, classRepresentation);
-            if (Consumer.class.isInstance(callBack)) {
-                repository.delete(query, Consumer.class.cast(callBack));
-                return null;
-            }
+    private Object getCallBack(Object[] args) {
+        return args[args.length - 1];
+    }
 
-            repository.delete(query);
+    private Object executeQuery(Object arg, ColumnQuery query) {
+        Object callBack = arg;
+        if (Consumer.class.isInstance(callBack)) {
+            repository.find(query, Consumer.class.cast(callBack));
             return null;
         }
 
-        return null;
+        throw new DynamicQueryException("On find async method you must put a java.util.function.Consumer" +
+                " as end parameter as callback");
     }
 
 

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryProxy.java
@@ -27,6 +27,8 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 
+import static org.jnosql.artemis.column.query.ColumnRepositoryType.getDeleteQuery;
+import static org.jnosql.artemis.column.query.ColumnRepositoryType.getQuery;
 import static org.jnosql.artemis.column.query.ReturnTypeConverterUtil.returnObject;
 
 
@@ -81,10 +83,12 @@ class ColumnRepositoryProxy<T> implements InvocationHandler {
                 template.delete(deleteQuery);
                 return Void.class;
             case QUERY:
-                ColumnQuery columnQuery = ColumnRepositoryType.getColumnQuery(args).get();
+                ColumnQuery columnQuery = getQuery(args).get();
                 return returnObject(columnQuery, template, typeClass, method);
             case QUERY_DELETE:
-
+                ColumnDeleteQuery columnDeleteQuery = getDeleteQuery(args).get();
+                template.delete(columnDeleteQuery);
+                return Void.class;
             default:
                 return Void.class;
 

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryProxy.java
@@ -39,11 +39,6 @@ import static org.jnosql.artemis.column.query.ReturnTypeConverterUtil.returnObje
  */
 class ColumnRepositoryProxy<T> implements InvocationHandler {
 
-    private static final String SAVE = "save";
-    private static final String UPDATE = "update";
-    private static final String FIND_BY = "findBy";
-    private static final String DELETE_BY = "deleteBy";
-
     private final Class<T> typeClass;
 
     private final ColumnTemplate template;

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryType.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryType.java
@@ -52,20 +52,20 @@ enum ColumnRepositoryType {
     }
 
     private static boolean isQuery(Object[] args) {
-        return getColumnQuery(args).isPresent();
+        return getQuery(args).isPresent();
     }
 
     private static boolean isQueryDelete(Object[] args) {
-        return getColumnDeleteQuery(args).isPresent();
+        return getDeleteQuery(args).isPresent();
     }
 
-    static Optional<ColumnQuery> getColumnQuery(Object[] args) {
+    static Optional<ColumnQuery> getQuery(Object[] args) {
         return Stream.of(args)
                 .filter(ColumnQuery.class::isInstance).map(ColumnQuery.class::cast)
                 .findFirst();
     }
 
-    static Optional<ColumnDeleteQuery> getColumnDeleteQuery(Object[] args) {
+    static Optional<ColumnDeleteQuery> getDeleteQuery(Object[] args) {
         return Stream.of(args)
                 .filter(ColumnDeleteQuery.class::isInstance)
                 .map(ColumnDeleteQuery.class::cast)

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryType.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryType.java
@@ -15,8 +15,8 @@
  */
 package org.jnosql.artemis.column.query;
 
-import org.jnosql.diana.api.document.DocumentDeleteQuery;
-import org.jnosql.diana.api.document.DocumentQuery;
+import org.jnosql.diana.api.column.ColumnDeleteQuery;
+import org.jnosql.diana.api.column.ColumnQuery;
 
 import java.lang.reflect.Method;
 import java.util.Optional;
@@ -35,11 +35,11 @@ enum ColumnRepositoryType {
             default:
         }
 
-        if (isDocumentType(args)) {
+        if (isQuery(args)) {
             return QUERY;
         }
 
-        if (isDocumentDeleteType(args)) {
+        if (isQueryDelete(args)) {
             return QUERY_DELETE;
         }
 
@@ -51,24 +51,24 @@ enum ColumnRepositoryType {
         return UNKNOWN;
     }
 
-    private static boolean isDocumentType(Object[] args) {
+    private static boolean isQuery(Object[] args) {
         return getDocumentQuery(args).isPresent();
     }
 
-    private static boolean isDocumentDeleteType(Object[] args) {
+    private static boolean isQueryDelete(Object[] args) {
         return getDocumentDeleteQuery(args).isPresent();
     }
 
-    static Optional<DocumentQuery> getDocumentQuery(Object[] args) {
+    static Optional<ColumnQuery> getDocumentQuery(Object[] args) {
         return Stream.of(args)
-                .filter(DocumentQuery.class::isInstance).map(DocumentQuery.class::cast)
+                .filter(ColumnQuery.class::isInstance).map(ColumnQuery.class::cast)
                 .findFirst();
     }
 
-    static Optional<DocumentDeleteQuery> getDocumentDeleteQuery(Object[] args) {
+    static Optional<ColumnDeleteQuery> getDocumentDeleteQuery(Object[] args) {
         return Stream.of(args)
-                .filter(DocumentDeleteQuery.class::isInstance)
-                .map(DocumentDeleteQuery.class::cast)
+                .filter(ColumnDeleteQuery.class::isInstance)
+                .map(ColumnDeleteQuery.class::cast)
                 .findFirst();
     }
 

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryType.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryType.java
@@ -13,8 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jnosql.artemis.document.query;
-
+package org.jnosql.artemis.column.query;
 
 import org.jnosql.diana.api.document.DocumentDeleteQuery;
 import org.jnosql.diana.api.document.DocumentQuery;
@@ -23,12 +22,11 @@ import java.lang.reflect.Method;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-enum DocumentRepositoryType {
-
+enum ColumnRepositoryType {
     DEFAULT, FIND_BY, DELETE_BY, QUERY, QUERY_DELETE, UNKNOWN;
 
 
-    static DocumentRepositoryType of(Method method, Object[] args) {
+    static ColumnRepositoryType of(Method method, Object[] args) {
         String methodName = method.getName();
         switch (methodName) {
             case "save":

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryType.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/ColumnRepositoryType.java
@@ -52,20 +52,20 @@ enum ColumnRepositoryType {
     }
 
     private static boolean isQuery(Object[] args) {
-        return getDocumentQuery(args).isPresent();
+        return getColumnQuery(args).isPresent();
     }
 
     private static boolean isQueryDelete(Object[] args) {
-        return getDocumentDeleteQuery(args).isPresent();
+        return getColumnDeleteQuery(args).isPresent();
     }
 
-    static Optional<ColumnQuery> getDocumentQuery(Object[] args) {
+    static Optional<ColumnQuery> getColumnQuery(Object[] args) {
         return Stream.of(args)
                 .filter(ColumnQuery.class::isInstance).map(ColumnQuery.class::cast)
                 .findFirst();
     }
 
-    static Optional<ColumnDeleteQuery> getDocumentDeleteQuery(Object[] args) {
+    static Optional<ColumnDeleteQuery> getColumnDeleteQuery(Object[] args) {
         return Stream.of(args)
                 .filter(ColumnDeleteQuery.class::isInstance)
                 .map(ColumnDeleteQuery.class::cast)

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/CrudRepositoryAsyncColumnBean.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/CrudRepositoryAsyncColumnBean.java
@@ -89,7 +89,7 @@ public class CrudRepositoryAsyncColumnBean implements Bean<RepositoryAsync>, Pas
         ClassRepresentations classRepresentations = getInstance(ClassRepresentations.class);
         ColumnTemplateAsync repository = provider.isEmpty() ? getInstance(ColumnTemplateAsync.class) :
                 getInstance(ColumnTemplateAsync.class, provider);
-        ColumnCrudRepositoryAsyncProxy handler = new ColumnCrudRepositoryAsyncProxy(repository,
+        ColumnRepositoryAsyncProxy handler = new ColumnRepositoryAsyncProxy(repository,
                 classRepresentations, type);
         return (RepositoryAsync) Proxy.newProxyInstance(type.getClassLoader(),
                 new Class[]{type},

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/CrudRepositoryColumnBean.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/CrudRepositoryColumnBean.java
@@ -89,7 +89,7 @@ public class CrudRepositoryColumnBean implements Bean<Repository>, PassivationCa
         ClassRepresentations classRepresentations = getInstance(ClassRepresentations.class);
         ColumnTemplate repository = provider.isEmpty() ? getInstance(ColumnTemplate.class) :
                 getInstance(ColumnTemplate.class, provider);
-        ColumnCrudRepositoryProxy handler = new ColumnCrudRepositoryProxy(repository,
+        ColumnRepositoryProxy handler = new ColumnRepositoryProxy(repository,
                 classRepresentations, type);
         return (Repository) Proxy.newProxyInstance(type.getClassLoader(),
                 new Class[]{type},

--- a/artemis-core/src/main/java/org/jnosql/artemis/column/query/ReturnTypeConverterUtil.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/column/query/ReturnTypeConverterUtil.java
@@ -37,11 +37,11 @@ public final class ReturnTypeConverterUtil {
     }
 
 
-    public static Object returnObject(ColumnQuery query, ColumnTemplate repository, Class typeClass, Method method) {
+    public static Object returnObject(ColumnQuery query, ColumnTemplate template, Class typeClass, Method method) {
         Class<?> returnType = method.getReturnType();
 
         if (typeClass.equals(returnType)) {
-            Optional<Object> optional = repository.singleResult(query);
+            Optional<Object> optional = template.singleResult(query);
             if (optional.isPresent()) {
                 return optional.get();
             } else {
@@ -49,20 +49,20 @@ public final class ReturnTypeConverterUtil {
             }
 
         } else if (Optional.class.equals(returnType)) {
-            return repository.singleResult(query);
+            return template.singleResult(query);
         } else if (List.class.equals(returnType)
                 || Iterable.class.equals(returnType)
                 || Collection.class.equals(returnType)) {
-            return repository.find(query);
+            return template.find(query);
         } else if (Set.class.equals(returnType)) {
-            return new HashSet<>(repository.find(query));
+            return new HashSet<>(template.find(query));
         } else if (Queue.class.equals(returnType)) {
-            return new PriorityQueue<>(repository.find(query));
+            return new PriorityQueue<>(template.find(query));
         } else if (Stream.class.equals(returnType)) {
-            return repository.find(query).stream();
+            return template.find(query).stream();
         }
 
-        return repository.find(query);
+        return template.find(query);
     }
 
 }

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/AbstractDocumentRepository.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/AbstractDocumentRepository.java
@@ -25,35 +25,35 @@ import java.time.Duration;
  */
 public abstract class AbstractDocumentRepository implements Repository {
 
-    protected abstract DocumentTemplate getDocumentRepository();
+    protected abstract DocumentTemplate getDocumentTemplate();
 
     @Override
     public Object save(Object entity) throws NullPointerException {
-        return getDocumentRepository().save(entity);
+        return getDocumentTemplate().save(entity);
     }
 
     @Override
     public Object save(Object entity, Duration ttl) {
-        return getDocumentRepository().save(entity, ttl);
+        return getDocumentTemplate().save(entity, ttl);
     }
 
     @Override
     public Iterable save(Iterable entities) throws NullPointerException {
-        return getDocumentRepository().save(entities);
+        return getDocumentTemplate().save(entities);
     }
 
     @Override
     public Iterable save(Iterable entities, Duration ttl) throws NullPointerException {
-        return getDocumentRepository().save(entities, ttl);
+        return getDocumentTemplate().save(entities, ttl);
     }
 
     @Override
     public Object update(Object entity) {
-        return getDocumentRepository().update(entity);
+        return getDocumentTemplate().update(entity);
     }
 
     @Override
     public Iterable update(Iterable entities) throws NullPointerException {
-        return getDocumentRepository().update(entities);
+        return getDocumentTemplate().update(entities);
     }
 }

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/AbstractDocumentRepository.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/AbstractDocumentRepository.java
@@ -25,35 +25,35 @@ import java.time.Duration;
  */
 public abstract class AbstractDocumentRepository implements Repository {
 
-    protected abstract DocumentTemplate getDocumentTemplate();
+    protected abstract DocumentTemplate getTemplate();
 
     @Override
     public Object save(Object entity) throws NullPointerException {
-        return getDocumentTemplate().save(entity);
+        return getTemplate().save(entity);
     }
 
     @Override
     public Object save(Object entity, Duration ttl) {
-        return getDocumentTemplate().save(entity, ttl);
+        return getTemplate().save(entity, ttl);
     }
 
     @Override
     public Iterable save(Iterable entities) throws NullPointerException {
-        return getDocumentTemplate().save(entities);
+        return getTemplate().save(entities);
     }
 
     @Override
     public Iterable save(Iterable entities, Duration ttl) throws NullPointerException {
-        return getDocumentTemplate().save(entities, ttl);
+        return getTemplate().save(entities, ttl);
     }
 
     @Override
     public Object update(Object entity) {
-        return getDocumentTemplate().update(entity);
+        return getTemplate().update(entity);
     }
 
     @Override
     public Iterable update(Iterable entities) throws NullPointerException {
-        return getDocumentTemplate().update(entities);
+        return getTemplate().update(entities);
     }
 }

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/AbstractDocumentRepositoryAsync.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/AbstractDocumentRepositoryAsync.java
@@ -29,50 +29,50 @@ import java.util.function.Consumer;
 public abstract class AbstractDocumentRepositoryAsync implements RepositoryAsync {
 
 
-    protected abstract DocumentTemplateAsync getDocumentRepository();
+    protected abstract DocumentTemplateAsync getDocumentTemplate();
 
     @Override
     public void save(Object entity) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentRepository().save(entity);
+        getDocumentTemplate().save(entity);
     }
 
     @Override
     public void save(Object entity, Duration ttl) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentRepository().save(entity, ttl);
+        getDocumentTemplate().save(entity, ttl);
     }
 
     @Override
     public void save(Iterable entities) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentRepository().save(entities);
+        getDocumentTemplate().save(entities);
     }
 
     @Override
     public void save(Iterable entities, Duration ttl) throws NullPointerException {
-        getDocumentRepository().save(entities, ttl);
+        getDocumentTemplate().save(entities, ttl);
     }
 
     @Override
     public void update(Iterable entities) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentRepository().update(entities);
+        getDocumentTemplate().update(entities);
     }
 
     @Override
     public void update(Object entity) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentRepository().save(entity);
+        getDocumentTemplate().save(entity);
     }
 
     @Override
     public void update(Object entity, Consumer callBack) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentRepository().update(entity, callBack);
+        getDocumentTemplate().update(entity, callBack);
     }
 
     @Override
     public void save(Object entity, Duration ttl, Consumer callBack) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentRepository().save(entity, ttl, callBack);
+        getDocumentTemplate().save(entity, ttl, callBack);
     }
 
     @Override
     public void save(Object entity, Consumer callBack) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentRepository().save(entity, callBack);
+        getDocumentTemplate().save(entity, callBack);
     }
 }

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/AbstractDocumentRepositoryAsync.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/AbstractDocumentRepositoryAsync.java
@@ -29,50 +29,50 @@ import java.util.function.Consumer;
 public abstract class AbstractDocumentRepositoryAsync implements RepositoryAsync {
 
 
-    protected abstract DocumentTemplateAsync getDocumentTemplate();
+    protected abstract DocumentTemplateAsync getTemplate();
 
     @Override
     public void save(Object entity) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentTemplate().save(entity);
+        getTemplate().save(entity);
     }
 
     @Override
     public void save(Object entity, Duration ttl) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentTemplate().save(entity, ttl);
+        getTemplate().save(entity, ttl);
     }
 
     @Override
     public void save(Iterable entities) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentTemplate().save(entities);
+        getTemplate().save(entities);
     }
 
     @Override
     public void save(Iterable entities, Duration ttl) throws NullPointerException {
-        getDocumentTemplate().save(entities, ttl);
+        getTemplate().save(entities, ttl);
     }
 
     @Override
     public void update(Iterable entities) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentTemplate().update(entities);
+        getTemplate().update(entities);
     }
 
     @Override
     public void update(Object entity) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentTemplate().save(entity);
+        getTemplate().save(entity);
     }
 
     @Override
     public void update(Object entity, Consumer callBack) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentTemplate().update(entity, callBack);
+        getTemplate().update(entity, callBack);
     }
 
     @Override
     public void save(Object entity, Duration ttl, Consumer callBack) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentTemplate().save(entity, ttl, callBack);
+        getTemplate().save(entity, ttl, callBack);
     }
 
     @Override
     public void save(Object entity, Consumer callBack) throws ExecuteAsyncQueryException, UnsupportedOperationException, NullPointerException {
-        getDocumentTemplate().save(entity, callBack);
+        getTemplate().save(entity, callBack);
     }
 }

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentCrudRepositoryAsyncProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentCrudRepositoryAsyncProxy.java
@@ -80,10 +80,10 @@ class DocumentCrudRepositoryAsyncProxy<T> implements InvocationHandler {
             case DELETE_BY:
                 DocumentDeleteQuery deleteQuery = queryDeleteParser.parse(methodName, args, classRepresentation);
                 return executeDelete(args, deleteQuery);
-            case DOCUMENT_QUERY:
+            case QUERY:
                 DocumentQuery documentQuery = getDocumentQuery(args).get();
                 return executeQuery(getCallBack(args), documentQuery);
-            case DOCUMENT_DELETE:
+            case QUERY_DELETE:
                 return executeDelete(args, getDocumentDeleteQuery(args).get());
             default:
                 return null;

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentCrudRepositoryAsyncProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentCrudRepositoryAsyncProxy.java
@@ -41,7 +41,7 @@ class DocumentCrudRepositoryAsyncProxy<T> implements InvocationHandler {
 
     private final Class<T> typeClass;
 
-    private final DocumentTemplateAsync repository;
+    private final DocumentTemplateAsync templateAsync;
 
 
     private final DocumentRepositoryAsync crudRepository;
@@ -53,9 +53,9 @@ class DocumentCrudRepositoryAsyncProxy<T> implements InvocationHandler {
     private final DocumentQueryDeleteParser queryDeleteParser;
 
 
-    DocumentCrudRepositoryAsyncProxy(DocumentTemplateAsync repository, ClassRepresentations classRepresentations, Class<?> repositoryType) {
-        this.repository = repository;
-        this.crudRepository = new DocumentRepositoryAsync(repository);
+    DocumentCrudRepositoryAsyncProxy(DocumentTemplateAsync templateAsync, ClassRepresentations classRepresentations, Class<?> repositoryType) {
+        this.templateAsync = templateAsync;
+        this.crudRepository = new DocumentRepositoryAsync(templateAsync);
         this.typeClass = Class.class.cast(ParameterizedType.class.cast(repositoryType.getGenericInterfaces()[0])
                 .getActualTypeArguments()[0]);
         this.classRepresentation = classRepresentations.get(typeClass);
@@ -94,9 +94,9 @@ class DocumentCrudRepositoryAsyncProxy<T> implements InvocationHandler {
     private Object executeDelete(Object[] args, DocumentDeleteQuery query1) {
         Object callBack = getCallBack(args);
         if (Consumer.class.isInstance(callBack)) {
-            repository.delete(query1, Consumer.class.cast(callBack));
+            templateAsync.delete(query1, Consumer.class.cast(callBack));
         } else {
-            repository.delete(query1);
+            templateAsync.delete(query1);
         }
         return Void.class;
     }
@@ -108,7 +108,7 @@ class DocumentCrudRepositoryAsyncProxy<T> implements InvocationHandler {
     private Object executeQuery(Object arg, DocumentQuery query) {
         Object callBack = arg;
         if (Consumer.class.isInstance(callBack)) {
-            repository.find(query, Consumer.class.cast(callBack));
+            templateAsync.find(query, Consumer.class.cast(callBack));
         } else {
             throw new DynamicQueryException("On find async method you must put a java.util.function.Consumer" +
                     " as end parameter as callback");
@@ -119,15 +119,15 @@ class DocumentCrudRepositoryAsyncProxy<T> implements InvocationHandler {
 
     class DocumentRepositoryAsync extends AbstractDocumentRepositoryAsync implements RepositoryAsync {
 
-        private final DocumentTemplateAsync repository;
+        private final DocumentTemplateAsync template;
 
-        DocumentRepositoryAsync(DocumentTemplateAsync repository) {
-            this.repository = repository;
+        DocumentRepositoryAsync(DocumentTemplateAsync template) {
+            this.template = template;
         }
 
         @Override
-        protected DocumentTemplateAsync getDocumentRepository() {
-            return repository;
+        protected DocumentTemplateAsync getDocumentTemplate() {
+            return template;
         }
     }
 }

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentCrudRepositoryProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentCrudRepositoryProxy.java
@@ -41,7 +41,7 @@ class DocumentCrudRepositoryProxy<T> implements InvocationHandler {
 
     private final Class<T> typeClass;
 
-    private final DocumentTemplate repository;
+    private final DocumentTemplate template;
 
 
     private final DocumentRepository crudRepository;
@@ -53,9 +53,9 @@ class DocumentCrudRepositoryProxy<T> implements InvocationHandler {
     private final DocumentQueryDeleteParser deleteQueryParser;
 
 
-    DocumentCrudRepositoryProxy(DocumentTemplate repository, ClassRepresentations classRepresentations, Class<?> repositoryType) {
-        this.repository = repository;
-        this.crudRepository = new DocumentRepository(repository);
+    DocumentCrudRepositoryProxy(DocumentTemplate template, ClassRepresentations classRepresentations, Class<?> repositoryType) {
+        this.template = template;
+        this.crudRepository = new DocumentRepository(template);
         this.typeClass = Class.class.cast(ParameterizedType.class.cast(repositoryType.getGenericInterfaces()[0])
                 .getActualTypeArguments()[0]);
         this.classRepresentation = classRepresentations.get(typeClass);
@@ -75,16 +75,16 @@ class DocumentCrudRepositoryProxy<T> implements InvocationHandler {
                 return method.invoke(crudRepository, args);
             case FIND_BY:
                 DocumentQuery query = queryParser.parse(methodName, args, classRepresentation);
-                return returnObject(query, repository, typeClass, method);
+                return returnObject(query, template, typeClass, method);
             case DELETE_BY:
-                repository.delete(deleteQueryParser.parse(methodName, args, classRepresentation));
+                template.delete(deleteQueryParser.parse(methodName, args, classRepresentation));
                 return null;
             case DOCUMENT_QUERY:
                 DocumentQuery documentQuery = getDocumentQuery(args).get();
-                return returnObject(documentQuery, repository, typeClass, method);
+                return returnObject(documentQuery, template, typeClass, method);
             case DOCUMENT_DELETE:
                 DocumentDeleteQuery deleteQuery = getDocumentDeleteQuery(args).get();
-                repository.delete(deleteQuery);
+                template.delete(deleteQuery);
                 return null;
             default:
                 return null;

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentCrudRepositoryProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentCrudRepositoryProxy.java
@@ -79,10 +79,10 @@ class DocumentCrudRepositoryProxy<T> implements InvocationHandler {
             case DELETE_BY:
                 template.delete(deleteQueryParser.parse(methodName, args, classRepresentation));
                 return null;
-            case DOCUMENT_QUERY:
+            case QUERY:
                 DocumentQuery documentQuery = getDocumentQuery(args).get();
                 return returnObject(documentQuery, template, typeClass, method);
-            case DOCUMENT_DELETE:
+            case QUERY_DELETE:
                 DocumentDeleteQuery deleteQuery = getDocumentDeleteQuery(args).get();
                 template.delete(deleteQuery);
                 return null;

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentQueryDeleteParser.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentQueryDeleteParser.java
@@ -25,7 +25,7 @@ import static org.jnosql.artemis.document.query.DocumentQueryParserUtil.toCondit
 
 /**
  * Class the returns a {@link DocumentDeleteQuery}
- * on {@link DocumentCrudRepositoryProxy}
+ * on {@link DocumentRepositoryProxy}
  */
 public class DocumentQueryDeleteParser {
 

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentQueryParser.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentQueryParser.java
@@ -33,7 +33,7 @@ import static org.jnosql.diana.api.Sort.SortType.DESC;
 
 /**
  * Class the returns a {@link org.jnosql.diana.api.document.DocumentQuery}
- * on {@link DocumentCrudRepositoryProxy}
+ * on {@link DocumentRepositoryProxy}
  */
 public class DocumentQueryParser {
 

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryAsyncBean.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryAsyncBean.java
@@ -37,7 +37,7 @@ import java.util.Set;
 /**
  * Artemis discoveryBean to CDI extension to register {@link RepositoryAsync}
  */
-public class CrudRepositoryAsyncDocumentBean implements Bean<RepositoryAsync>, PassivationCapable {
+public class DocumentRepositoryAsyncBean implements Bean<RepositoryAsync>, PassivationCapable {
 
     private final Class type;
 
@@ -56,7 +56,7 @@ public class CrudRepositoryAsyncDocumentBean implements Bean<RepositoryAsync>, P
      * @param beanManager the beanManager
      * @param provider    the provider name, that must be a
      */
-    public CrudRepositoryAsyncDocumentBean(Class type, BeanManager beanManager, String provider) {
+    public DocumentRepositoryAsyncBean(Class type, BeanManager beanManager, String provider) {
         this.type = type;
         this.beanManager = beanManager;
         this.types = Collections.singleton(type);
@@ -89,7 +89,7 @@ public class CrudRepositoryAsyncDocumentBean implements Bean<RepositoryAsync>, P
         ClassRepresentations classRepresentations = getInstance(ClassRepresentations.class);
         DocumentTemplateAsync repository = provider.isEmpty() ? getInstance(DocumentTemplateAsync.class) :
                 getInstance(DocumentTemplateAsync.class, provider);
-        DocumentCrudRepositoryAsyncProxy handler = new DocumentCrudRepositoryAsyncProxy(repository,
+        DocumentRepositoryAsyncProxy handler = new DocumentRepositoryAsyncProxy(repository,
                 classRepresentations, type);
         return (RepositoryAsync) Proxy.newProxyInstance(type.getClassLoader(),
                 new Class[]{type},

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryAsyncProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryAsyncProxy.java
@@ -37,7 +37,7 @@ import static org.jnosql.artemis.document.query.DocumentRepositoryType.getDocume
  *
  * @param <T> the type
  */
-class DocumentCrudRepositoryAsyncProxy<T> implements InvocationHandler {
+class DocumentRepositoryAsyncProxy<T> implements InvocationHandler {
 
     private final Class<T> typeClass;
 
@@ -53,7 +53,7 @@ class DocumentCrudRepositoryAsyncProxy<T> implements InvocationHandler {
     private final DocumentQueryDeleteParser queryDeleteParser;
 
 
-    DocumentCrudRepositoryAsyncProxy(DocumentTemplateAsync templateAsync, ClassRepresentations classRepresentations, Class<?> repositoryType) {
+    DocumentRepositoryAsyncProxy(DocumentTemplateAsync templateAsync, ClassRepresentations classRepresentations, Class<?> repositoryType) {
         this.templateAsync = templateAsync;
         this.crudRepository = new DocumentRepositoryAsync(templateAsync);
         this.typeClass = Class.class.cast(ParameterizedType.class.cast(repositoryType.getGenericInterfaces()[0])

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryAsyncProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryAsyncProxy.java
@@ -29,8 +29,8 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.util.function.Consumer;
 
-import static org.jnosql.artemis.document.query.DocumentRepositoryType.getDocumentDeleteQuery;
-import static org.jnosql.artemis.document.query.DocumentRepositoryType.getDocumentQuery;
+import static org.jnosql.artemis.document.query.DocumentRepositoryType.getDeleteQuery;
+import static org.jnosql.artemis.document.query.DocumentRepositoryType.getQuery;
 
 /**
  * Proxy handle to generate {@link RepositoryAsync}
@@ -81,10 +81,10 @@ class DocumentRepositoryAsyncProxy<T> implements InvocationHandler {
                 DocumentDeleteQuery deleteQuery = queryDeleteParser.parse(methodName, args, classRepresentation);
                 return executeDelete(args, deleteQuery);
             case QUERY:
-                DocumentQuery documentQuery = getDocumentQuery(args).get();
+                DocumentQuery documentQuery = getQuery(args).get();
                 return executeQuery(getCallBack(args), documentQuery);
             case QUERY_DELETE:
-                return executeDelete(args, getDocumentDeleteQuery(args).get());
+                return executeDelete(args, getDeleteQuery(args).get());
             default:
                 return null;
         }

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryAsyncProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryAsyncProxy.java
@@ -126,7 +126,7 @@ class DocumentRepositoryAsyncProxy<T> implements InvocationHandler {
         }
 
         @Override
-        protected DocumentTemplateAsync getDocumentTemplate() {
+        protected DocumentTemplateAsync getTemplate() {
             return template;
         }
     }

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryProxy.java
@@ -27,8 +27,8 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 
-import static org.jnosql.artemis.document.query.DocumentRepositoryType.getDocumentDeleteQuery;
-import static org.jnosql.artemis.document.query.DocumentRepositoryType.getDocumentQuery;
+import static org.jnosql.artemis.document.query.DocumentRepositoryType.getDeleteQuery;
+import static org.jnosql.artemis.document.query.DocumentRepositoryType.getQuery;
 import static org.jnosql.artemis.document.query.ReturnTypeConverterUtil.returnObject;
 
 
@@ -80,10 +80,10 @@ class DocumentRepositoryProxy<T> implements InvocationHandler {
                 template.delete(deleteQueryParser.parse(methodName, args, classRepresentation));
                 return null;
             case QUERY:
-                DocumentQuery documentQuery = getDocumentQuery(args).get();
+                DocumentQuery documentQuery = getQuery(args).get();
                 return returnObject(documentQuery, template, typeClass, method);
             case QUERY_DELETE:
-                DocumentDeleteQuery deleteQuery = getDocumentDeleteQuery(args).get();
+                DocumentDeleteQuery deleteQuery = getDeleteQuery(args).get();
                 template.delete(deleteQuery);
                 return null;
             default:

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryProxy.java
@@ -37,7 +37,7 @@ import static org.jnosql.artemis.document.query.ReturnTypeConverterUtil.returnOb
  *
  * @param <T> the type
  */
-class DocumentCrudRepositoryProxy<T> implements InvocationHandler {
+class DocumentRepositoryProxy<T> implements InvocationHandler {
 
     private final Class<T> typeClass;
 
@@ -53,7 +53,7 @@ class DocumentCrudRepositoryProxy<T> implements InvocationHandler {
     private final DocumentQueryDeleteParser deleteQueryParser;
 
 
-    DocumentCrudRepositoryProxy(DocumentTemplate template, ClassRepresentations classRepresentations, Class<?> repositoryType) {
+    DocumentRepositoryProxy(DocumentTemplate template, ClassRepresentations classRepresentations, Class<?> repositoryType) {
         this.template = template;
         this.crudRepository = new DocumentRepository(template);
         this.typeClass = Class.class.cast(ParameterizedType.class.cast(repositoryType.getGenericInterfaces()[0])

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryProxy.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryProxy.java
@@ -101,7 +101,7 @@ class DocumentRepositoryProxy<T> implements InvocationHandler {
         }
 
         @Override
-        protected DocumentTemplate getDocumentTemplate() {
+        protected DocumentTemplate getTemplate() {
             return template;
         }
     }

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryType.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryType.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Otavio Santana and others
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jnosql.artemis.document.query;
+
+
+import org.jnosql.diana.api.document.DocumentQuery;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+enum DocumentRepositoryType {
+
+    DEFAULT, FIND_BY, DELETE_BY, DOCUMENT_QUERY, UNKNOWN;
+
+
+    static DocumentRepositoryType of(Method method, Object[] args) {
+        String methodName = method.getName();
+        switch (methodName) {
+            case "save":
+            case "update":
+                return DEFAULT;
+            default:
+        }
+
+        Optional<DocumentQuery> documentQuery = getDocumentQuery(args);
+
+        if (documentQuery.isPresent()) {
+            return DOCUMENT_QUERY;
+        }
+
+        if (methodName.startsWith("findBy")) {
+            return FIND_BY;
+        } else if (methodName.startsWith("deleteBy")) {
+            return DELETE_BY;
+        }
+        return UNKNOWN;
+    }
+
+    static Optional<DocumentQuery> getDocumentQuery(Object[] args) {
+        return Stream.of(args)
+                    .filter(DocumentQuery.class::isInstance).map(DocumentQuery.class::cast)
+                    .findFirst();
+    }
+
+}

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryType.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryType.java
@@ -37,11 +37,11 @@ enum DocumentRepositoryType {
             default:
         }
 
-        if (isDocumentType(args)) {
+        if (isQuery(args)) {
             return QUERY;
         }
 
-        if (isDocumentDeleteType(args)) {
+        if (isQueryDelete(args)) {
             return QUERY_DELETE;
         }
 
@@ -53,11 +53,11 @@ enum DocumentRepositoryType {
         return UNKNOWN;
     }
 
-    private static boolean isDocumentType(Object[] args) {
+    private static boolean isQuery(Object[] args) {
         return getDocumentQuery(args).isPresent();
     }
 
-    private static boolean isDocumentDeleteType(Object[] args) {
+    private static boolean isQueryDelete(Object[] args) {
         return getDocumentDeleteQuery(args).isPresent();
     }
 

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryType.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryType.java
@@ -16,6 +16,7 @@
 package org.jnosql.artemis.document.query;
 
 
+import org.jnosql.diana.api.document.DocumentDeleteQuery;
 import org.jnosql.diana.api.document.DocumentQuery;
 
 import java.lang.reflect.Method;
@@ -24,7 +25,7 @@ import java.util.stream.Stream;
 
 enum DocumentRepositoryType {
 
-    DEFAULT, FIND_BY, DELETE_BY, DOCUMENT_QUERY, UNKNOWN;
+    DEFAULT, FIND_BY, DELETE_BY, DOCUMENT_QUERY, DOCUMENT_DELETE, UNKNOWN;
 
 
     static DocumentRepositoryType of(Method method, Object[] args) {
@@ -36,10 +37,12 @@ enum DocumentRepositoryType {
             default:
         }
 
-        Optional<DocumentQuery> documentQuery = getDocumentQuery(args);
-
-        if (documentQuery.isPresent()) {
+        if (isDocumentType(args)) {
             return DOCUMENT_QUERY;
+        }
+
+        if (isDocumentDeleteType(args)) {
+            return DOCUMENT_DELETE;
         }
 
         if (methodName.startsWith("findBy")) {
@@ -50,10 +53,25 @@ enum DocumentRepositoryType {
         return UNKNOWN;
     }
 
+    private static boolean isDocumentType(Object[] args) {
+        return getDocumentQuery(args).isPresent();
+    }
+
+    private static boolean isDocumentDeleteType(Object[] args) {
+        return getDocumentDeleteQuery(args).isPresent();
+    }
+
     static Optional<DocumentQuery> getDocumentQuery(Object[] args) {
         return Stream.of(args)
-                    .filter(DocumentQuery.class::isInstance).map(DocumentQuery.class::cast)
-                    .findFirst();
+                .filter(DocumentQuery.class::isInstance).map(DocumentQuery.class::cast)
+                .findFirst();
+    }
+
+    static Optional<DocumentDeleteQuery> getDocumentDeleteQuery(Object[] args) {
+        return Stream.of(args)
+                .filter(DocumentDeleteQuery.class::isInstance)
+                .map(DocumentDeleteQuery.class::cast)
+                .findFirst();
     }
 
 }

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryType.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/DocumentRepositoryType.java
@@ -54,20 +54,20 @@ enum DocumentRepositoryType {
     }
 
     private static boolean isQuery(Object[] args) {
-        return getDocumentQuery(args).isPresent();
+        return getQuery(args).isPresent();
     }
 
     private static boolean isQueryDelete(Object[] args) {
-        return getDocumentDeleteQuery(args).isPresent();
+        return getDeleteQuery(args).isPresent();
     }
 
-    static Optional<DocumentQuery> getDocumentQuery(Object[] args) {
+    static Optional<DocumentQuery> getQuery(Object[] args) {
         return Stream.of(args)
                 .filter(DocumentQuery.class::isInstance).map(DocumentQuery.class::cast)
                 .findFirst();
     }
 
-    static Optional<DocumentDeleteQuery> getDocumentDeleteQuery(Object[] args) {
+    static Optional<DocumentDeleteQuery> getDeleteQuery(Object[] args) {
         return Stream.of(args)
                 .filter(DocumentDeleteQuery.class::isInstance)
                 .map(DocumentDeleteQuery.class::cast)

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/query/RepositoryDocumentBean.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/query/RepositoryDocumentBean.java
@@ -37,7 +37,7 @@ import java.util.Set;
 /**
  * Artemis discoveryBean to CDI extension to register {@link Repository}
  */
-public class CrudRepositoryDocumentBean implements Bean<Repository>, PassivationCapable {
+public class RepositoryDocumentBean implements Bean<Repository>, PassivationCapable {
 
     private final Class type;
 
@@ -56,7 +56,7 @@ public class CrudRepositoryDocumentBean implements Bean<Repository>, Passivation
      * @param beanManager the beanManager
      * @param provider    the provider name, that must be a
      */
-    public CrudRepositoryDocumentBean(Class type, BeanManager beanManager, String provider) {
+    public RepositoryDocumentBean(Class type, BeanManager beanManager, String provider) {
         this.type = type;
         this.beanManager = beanManager;
         this.types = Collections.singleton(type);
@@ -89,7 +89,7 @@ public class CrudRepositoryDocumentBean implements Bean<Repository>, Passivation
         ClassRepresentations classRepresentations = getInstance(ClassRepresentations.class);
         DocumentTemplate repository = provider.isEmpty() ? getInstance(DocumentTemplate.class) :
                 getInstance(DocumentTemplate.class, provider);
-        DocumentCrudRepositoryProxy handler = new DocumentCrudRepositoryProxy(repository,
+        DocumentRepositoryProxy handler = new DocumentRepositoryProxy(repository,
                 classRepresentations, type);
         return (Repository) Proxy.newProxyInstance(type.getClassLoader(),
                 new Class[]{type},

--- a/artemis-core/src/main/java/org/jnosql/artemis/document/spi/DocumentCollectionProducerExtension.java
+++ b/artemis-core/src/main/java/org/jnosql/artemis/document/spi/DocumentCollectionProducerExtension.java
@@ -20,8 +20,8 @@ import org.jnosql.artemis.Repository;
 import org.jnosql.artemis.RepositoryAsync;
 import org.jnosql.artemis.Database;
 import org.jnosql.artemis.Databases;
-import org.jnosql.artemis.document.query.CrudRepositoryAsyncDocumentBean;
-import org.jnosql.artemis.document.query.CrudRepositoryDocumentBean;
+import org.jnosql.artemis.document.query.DocumentRepositoryAsyncBean;
+import org.jnosql.artemis.document.query.RepositoryDocumentBean;
 import org.jnosql.diana.api.document.DocumentCollectionManager;
 import org.jnosql.diana.api.document.DocumentCollectionManagerAsync;
 
@@ -104,22 +104,22 @@ public class DocumentCollectionProducerExtension implements Extension {
         });
 
         databasesAsync.forEach(type -> {
-            final DocumentRepositoryAsyncBean bean = new DocumentRepositoryAsyncBean(beanManager, type.provider());
+            final org.jnosql.artemis.document.spi.DocumentRepositoryAsyncBean bean = new org.jnosql.artemis.document.spi.DocumentRepositoryAsyncBean(beanManager, type.provider());
             afterBeanDiscovery.addBean(bean);
         });
 
         crudTypes.forEach(type -> {
-            afterBeanDiscovery.addBean(new CrudRepositoryDocumentBean(type, beanManager, ""));
+            afterBeanDiscovery.addBean(new RepositoryDocumentBean(type, beanManager, ""));
             databases.forEach(database -> {
-                final CrudRepositoryDocumentBean bean = new CrudRepositoryDocumentBean(type, beanManager, database.provider());
+                final RepositoryDocumentBean bean = new RepositoryDocumentBean(type, beanManager, database.provider());
                 afterBeanDiscovery.addBean(bean);
             });
         });
 
         crudAsyncTypes.forEach(type -> {
-            afterBeanDiscovery.addBean(new CrudRepositoryAsyncDocumentBean(type, beanManager, ""));
+            afterBeanDiscovery.addBean(new DocumentRepositoryAsyncBean(type, beanManager, ""));
             databasesAsync.forEach(database -> {
-                final CrudRepositoryAsyncDocumentBean bean = new CrudRepositoryAsyncDocumentBean(type, beanManager, database.provider());
+                final DocumentRepositoryAsyncBean bean = new DocumentRepositoryAsyncBean(type, beanManager, database.provider());
                 afterBeanDiscovery.addBean(bean);
             });
         });

--- a/artemis-core/src/test/java/org/jnosql/artemis/column/query/ColumnRepositoryAsyncProxyTest.java
+++ b/artemis-core/src/test/java/org/jnosql/artemis/column/query/ColumnRepositoryAsyncProxyTest.java
@@ -61,7 +61,7 @@ public class ColumnRepositoryAsyncProxyTest {
     public void setUp() {
         this.repository = Mockito.mock(ColumnTemplateAsync.class);
 
-        ColumnCrudRepositoryAsyncProxy handler = new ColumnCrudRepositoryAsyncProxy(repository,
+        ColumnRepositoryAsyncProxy handler = new ColumnRepositoryAsyncProxy(repository,
                 classRepresentations, PersonAsyncRepository.class);
 
 

--- a/artemis-core/src/test/java/org/jnosql/artemis/column/query/ColumnRepositoryProxyTest.java
+++ b/artemis-core/src/test/java/org/jnosql/artemis/column/query/ColumnRepositoryProxyTest.java
@@ -67,7 +67,7 @@ public class ColumnRepositoryProxyTest {
     public void setUp() {
         this.repository = Mockito.mock(ColumnTemplate.class);
 
-        ColumnCrudRepositoryProxy handler = new ColumnCrudRepositoryProxy(repository,
+        ColumnRepositoryProxy handler = new ColumnRepositoryProxy(repository,
                 classRepresentations, PersonRepository.class);
 
         when(repository.save(any(Person.class))).thenReturn(Person.builder().build());

--- a/artemis-core/src/test/java/org/jnosql/artemis/column/query/ColumnRepositoryProxyTest.java
+++ b/artemis-core/src/test/java/org/jnosql/artemis/column/query/ColumnRepositoryProxyTest.java
@@ -44,6 +44,7 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.jnosql.diana.api.column.ColumnCondition.eq;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -246,6 +247,32 @@ public class ColumnRepositoryProxyTest {
 
     }
 
+    @Test
+    public void shouldExecuteQuery() {
+        ArgumentCaptor<ColumnQuery> captor = ArgumentCaptor.forClass(ColumnQuery.class);
+        Person ada = Person.builder()
+                .withAge(20).withName("Ada").build();
+        when(repository.singleResult(Mockito.any(ColumnQuery.class)))
+                .thenReturn(Optional.of(ada));
+
+        ColumnQuery query = ColumnQuery.of("Person").and(eq(Column.of("name", "Ada")));
+        Person person = personRepository.query(query);
+        verify(repository).singleResult(captor.capture());
+        assertEquals(ada, person);
+        assertEquals(query, captor.getValue());
+
+    }
+
+    @Test
+    public void shouldDeleteQuery() {
+        ArgumentCaptor<ColumnDeleteQuery> captor = ArgumentCaptor.forClass(ColumnDeleteQuery.class);
+        ColumnDeleteQuery query = ColumnDeleteQuery.of("Person").and(eq(Column.of("name", "Ada")));
+        personRepository.deleteQuery(query);
+        verify(repository).delete(captor.capture());
+        assertEquals(query, captor.getValue());
+
+    }
+
     interface PersonRepository extends Repository<Person> {
 
         Person findByName(String name);
@@ -261,5 +288,9 @@ public class ColumnRepositoryProxyTest {
         Stream<Person> findByNameANDAgeOrderByName(String name, Integer age);
 
         Queue<Person> findByNameANDAgeOrderByAge(String name, Integer age);
+
+        Person query(ColumnQuery query);
+
+        void deleteQuery(ColumnDeleteQuery query);
     }
 }

--- a/artemis-core/src/test/java/org/jnosql/artemis/document/query/DocumentRepositoryAsyncProxyTest.java
+++ b/artemis-core/src/test/java/org/jnosql/artemis/document/query/DocumentRepositoryAsyncProxyTest.java
@@ -42,6 +42,7 @@ import java.util.function.Consumer;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.jnosql.diana.api.document.DocumentCondition.eq;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
@@ -258,6 +259,35 @@ public class DocumentRepositoryAsyncProxyTest {
 
     }
 
+    @Test
+    public void shouldExecuteQuery() {
+        Consumer<List<Person>> callback = v -> {
+        };
+
+        ArgumentCaptor<DocumentQuery> captor = ArgumentCaptor.forClass(DocumentQuery.class);
+        ArgumentCaptor<Consumer> consumerCaptor = ArgumentCaptor.forClass(Consumer.class);
+        DocumentQuery query = DocumentQuery.of("Person")
+                .with(eq(Document.of("name", "Ada")));
+
+        personRepository.query(query, callback);
+        verify(repository).find(captor.capture(), consumerCaptor.capture());
+        DocumentQuery queryCaptor = captor.getValue();
+        DocumentCondition condition = query.getCondition().get();
+        assertEquals(query, queryCaptor);
+        assertEquals(callback, consumerCaptor.getValue());
+    }
+
+    @Test
+    public void shouldExecuteDeleteQuery() {
+        ArgumentCaptor<DocumentDeleteQuery> captor = ArgumentCaptor.forClass(DocumentDeleteQuery.class);
+        DocumentDeleteQuery deleteQuery = DocumentDeleteQuery.of("Person")
+                .and(eq(Document.of("name", "Ada")));
+
+        personRepository.deleteQuery(deleteQuery);
+        verify(repository).delete(captor.capture());
+        assertEquals(deleteQuery, captor.getValue());
+    }
+
     interface PersonAsyncRepository extends RepositoryAsync<Person> {
 
         void deleteByName(String name);
@@ -273,6 +303,10 @@ public class DocumentRepositoryAsyncProxyTest {
         void findByName(String name, Sort sort, Consumer<List<Person>> callBack);
 
         void findByName(String name, Sort sort, Pagination pagination, Consumer<List<Person>> callBack);
+
+        void query(DocumentQuery query, Consumer<List<Person>> callBack);
+
+        void deleteQuery(DocumentDeleteQuery query);
     }
 
 }

--- a/artemis-core/src/test/java/org/jnosql/artemis/document/query/DocumentRepositoryAsyncProxyTest.java
+++ b/artemis-core/src/test/java/org/jnosql/artemis/document/query/DocumentRepositoryAsyncProxyTest.java
@@ -63,7 +63,7 @@ public class DocumentRepositoryAsyncProxyTest {
     public void setUp() {
         this.repository = Mockito.mock(DocumentTemplateAsync.class);
 
-        DocumentCrudRepositoryAsyncProxy handler = new DocumentCrudRepositoryAsyncProxy(repository,
+        DocumentRepositoryAsyncProxy handler = new DocumentRepositoryAsyncProxy(repository,
                 classRepresentations, PersonAsyncRepository.class);
 
 

--- a/artemis-core/src/test/java/org/jnosql/artemis/document/query/DocumentRepositoryProxyTest.java
+++ b/artemis-core/src/test/java/org/jnosql/artemis/document/query/DocumentRepositoryProxyTest.java
@@ -68,7 +68,7 @@ public class DocumentRepositoryProxyTest {
     public void setUp() {
         this.repository = Mockito.mock(DocumentTemplate.class);
 
-        DocumentCrudRepositoryProxy handler = new DocumentCrudRepositoryProxy(repository,
+        DocumentRepositoryProxy handler = new DocumentRepositoryProxy(repository,
                 classRepresentations, PersonRepository.class);
 
         when(repository.save(any(Person.class))).thenReturn(Person.builder().build());


### PR DESCRIPTION

This a new step feature, to allow when I'm running the query as DocumentRepository can execute DocumentQuery and DocumentDeleteQuery as ColumnRepository can execute both  DocumentQuery and ColumnDeleteQuery.

```java
 interface PersonAsyncRepository extends RepositoryAsync<Person> {

        void query(ColumnQuery query, Consumer<List<Person>> callBack);

        void deleteQuery(ColumnDeleteQuery query);
    }
```


```java
 interface PersonAsyncRepository extends RepositoryAsync<Person> {

        void query(DocumentQuery query, Consumer<List<Person>> callBack);

        void deleteQuery(DocumentDeleteQuery query);
    }
```
